### PR TITLE
Fix compilation errors on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ cmake-build-debug
 
 # ThirdParty
 ThirdParty
+
+# macOS
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,6 @@ set(CMAKE_BUILD_TYPE Release)
 find_package(Ceres REQUIRED)
 include_directories(${CERES_INCLUDE_DIRS})
 
-# glog
-# find_package(glog REQUIRED)
-# include_directories(${GLOG_INCLUDE_DIRS})
-
 # OpenCV
 find_package(OpenCV REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
@@ -21,12 +17,13 @@ find_package(OpenMP)
 message(STATUS "OpenMP flags = ${OpenMP_CXX_FLAGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+include_directories(${OpenMP_C_INCLUDE_DIRS})
 
 # Eigen
 find_package(Eigen3)
 include_directories(${Eigen3_INCLUDE_DIRS})
 
-set(ALL_LIBS glog gomp ${OpenCV_LIBS} ${CERES_LIBRARIES} ${Pangolin_LIBRARIES})
+set(ALL_LIBS ${OpenMP_libomp_LIBRARY} ${OpenCV_LIBS} ${CERES_LIBRARIES} ${Pangolin_LIBRARIES})
 
 # Pangolin
 if(DEFINED USE_GUI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(Ceres REQUIRED)
 include_directories(${CERES_INCLUDE_DIRS})
 
 # OpenCV
+find_package(Ade QUIET) # Work around linking issue caused by OpenCV4's cmake configuration, at least with the MacPorts release
 find_package(OpenCV REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
@@ -23,7 +24,7 @@ include_directories(${OpenMP_C_INCLUDE_DIRS})
 find_package(Eigen3)
 include_directories(${Eigen3_INCLUDE_DIRS})
 
-set(ALL_LIBS ${OpenMP_libomp_LIBRARY} ${OpenCV_LIBS} ${CERES_LIBRARIES} ${Pangolin_LIBRARIES})
+set(ALL_LIBS ${OpenMP_libomp_LIBRARY} ${OpenCV_LIBS} ${CERES_LIBRARIES})
 
 # Pangolin
 if(DEFINED USE_GUI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 
 # Eigen
-find_package(Eigen)
-include_directories(${Eigen_INCLUDE_DIRS})
+find_package(Eigen3)
+include_directories(${Eigen3_INCLUDE_DIRS})
 
 set(ALL_LIBS glog gomp ${OpenCV_LIBS} ${CERES_LIBRARIES} ${Pangolin_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 include_directories(${OpenMP_C_INCLUDE_DIRS})
 
 # Eigen
-find_package(Eigen3)
-include_directories(${Eigen3_INCLUDE_DIRS})
+find_package(Eigen3 REQUIRED)
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 set(ALL_LIBS ${OpenMP_libomp_LIBRARY} ${OpenCV_LIBS} ${CERES_LIBRARIES})
 

--- a/src/Utils/FastOpticalFlow/image.c
+++ b/src/Utils/FastOpticalFlow/image.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 
 #include "image.h"
@@ -21,7 +21,7 @@ image_t *image_new(const int width, const int height){
     image->width = width;
     image->height = height;  
     image->stride = ( (width+3) / 4 ) * 4;
-    image->c1 = (float*) memalign(16, image->stride*height*sizeof(float));
+    int res = posix_memalign((void **) &image->c1, 16, image->stride*height*sizeof(float));
     if(image->c1== NULL){
         fprintf(stderr, "Error: image_new() - not enough memory !\n");
         exit(1);
@@ -74,7 +74,7 @@ color_image_t *color_image_new(const int width, const int height){
     image->width = width;
     image->height = height;  
     image->stride = ( (width+3) / 4 ) * 4;
-    image->c1 = (float*) memalign(16, 3*image->stride*height*sizeof(float));
+    int res = posix_memalign((void **) &image->c1, 16, 3*image->stride*height*sizeof(float));
     if(image->c1 == NULL){
         fprintf(stderr, "Error: color_image_new() - not enough memory !\n");
         exit(1);
@@ -110,7 +110,8 @@ void resize_if_needed_newsize(image_t *im, const int w, const int h){
         im->width = w;
         im->height = h;
         im->stride = ((w+3)/4)*4;
-        float *data = (float *) memalign(16, im->stride*h*sizeof(float));
+        float *data;
+        int res = posix_memalign((void **) &data, 16, im->stride*h*sizeof(float));
         if(data == NULL){
             fprintf(stderr, "Error: resize_if_needed_newsize() - not enough memory !\n");
             exit(1);

--- a/src/Utils/FastOpticalFlow/oflow.cpp
+++ b/src/Utils/FastOpticalFlow/oflow.cpp
@@ -19,6 +19,8 @@
 #include "patchgrid.h"
 #include "refine_variational.h"
 
+#include <immintrin.h>
+
 
 using std::cout;
 using std::endl;
@@ -102,8 +104,8 @@ namespace OFC
   op.tv_solverit = tv_solverit_in;
   op.tv_sor = tv_sor_in;
   op.normoutlier_tmpbsq = (v4sf) {op.normoutlier*op.normoutlier, op.normoutlier*op.normoutlier, op.normoutlier*op.normoutlier, op.normoutlier*op.normoutlier};
-  op.normoutlier_tmp2bsq = __builtin_ia32_mulps(op.normoutlier_tmpbsq, op.twos);
-  op.normoutlier_tmp4bsq = __builtin_ia32_mulps(op.normoutlier_tmpbsq, op.fours);
+  op.normoutlier_tmp2bsq = _mm_mul_ps(op.normoutlier_tmpbsq, op.twos);
+  op.normoutlier_tmp4bsq = _mm_mul_ps(op.normoutlier_tmpbsq, op.fours);
 
   
   // Variables for algorithm timings

--- a/src/Utils/FastOpticalFlow/opticalflow_aux.c
+++ b/src/Utils/FastOpticalFlow/opticalflow_aux.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <math.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include "opticalflow_aux.h"
 
@@ -140,7 +140,8 @@ void compute_smoothness(image_t *dst_horiz, image_t *dst_vert, const image_t *uu
     image_delete(ux); image_delete(uy); image_delete(vx); image_delete(vy); 
     // compute dst_horiz
     v4sf *dsthp = (v4sf*) dst_horiz->c1; sp = (v4sf*) smoothness->c1;
-    float *sp_shift = (float*) memalign(16, stride*sizeof(float)); // aligned shifted copy of the current line
+    float *sp_shift;
+    int res = posix_memalign((void **) &sp_shift, 16, stride*sizeof(float)); // aligned shifted copy of the current line
     for(j=0;j<height;j++){
         // create an aligned copy
         float *spf = (float*) sp;

--- a/src/Utils/FastOpticalFlow/patch.cpp
+++ b/src/Utils/FastOpticalFlow/patch.cpp
@@ -230,7 +230,7 @@ void PatClass::LossComputeErrorImage(Eigen::Matrix<float, Eigen::Dynamic, 1>* pa
     for (int i=op->novals/4; i--; ++pd, ++pa, ++te, ++pw)
     {
       (*pd) = (*pa)-(*te);  // difference image
-      (*pw) = __builtin_ia32_andnps(op->negzero,  (*pd) );
+      (*pw) = _mm_and_ps(op->negzero,  (*pd) );
     }
   }
   else if (op->costfct==1) // L1 cost function
@@ -238,8 +238,8 @@ void PatClass::LossComputeErrorImage(Eigen::Matrix<float, Eigen::Dynamic, 1>* pa
     for (int i=op->novals/4; i--; ++pd, ++pa, ++te, ++pw)
     {
       (*pd) = (*pa)-(*te);   // difference image
-      (*pd) = __builtin_ia32_orps( __builtin_ia32_andps(op->negzero,  (*pd) )  , __builtin_ia32_sqrtps (__builtin_ia32_andnps(op->negzero,  (*pd) )) );  // sign(pdiff) * sqrt(abs(pdiff))
-      (*pw) = __builtin_ia32_andnps(op->negzero,  (*pd) );
+      (*pd) = _mm_or_ps( _mm_and_ps(op->negzero,  (*pd) )  , _mm_sqrt_ps (_mm_and_ps(op->negzero,  (*pd) )) );  // sign(pdiff) * sqrt(abs(pdiff))
+      (*pw) = _mm_and_ps(op->negzero,  (*pd) );
     }
   }
   else if (op->costfct==2) // Pseudo Huber cost function
@@ -247,14 +247,14 @@ void PatClass::LossComputeErrorImage(Eigen::Matrix<float, Eigen::Dynamic, 1>* pa
     for (int i=op->novals/4; i--; ++pd, ++pa, ++te, ++pw)
     {
       (*pd) = (*pa)-(*te);   // difference image
-      (*pd) = __builtin_ia32_orps(__builtin_ia32_andps(op->negzero,  (*pd) ), 
-                                  __builtin_ia32_sqrtps (
-                                    __builtin_ia32_mulps(                                                                                         // PSEUDO HUBER NORM
-                                          __builtin_ia32_sqrtps (op->ones + __builtin_ia32_divps(__builtin_ia32_mulps((*pd),(*pd)) , op->normoutlier_tmpbsq)) - op->ones, // PSEUDO HUBER NORM 
+      (*pd) = _mm_or_ps(_mm_and_ps(op->negzero,  (*pd) ), 
+                                  _mm_sqrt_ps (
+                                    _mm_mul_ps(                                                                                         // PSEUDO HUBER NORM
+                                          _mm_sqrt_ps (op->ones + _mm_div_ps(_mm_mul_ps((*pd),(*pd)) , op->normoutlier_tmpbsq)) - op->ones, // PSEUDO HUBER NORM 
                                           op->normoutlier_tmp2bsq)                                                                                                // PSEUDO HUBER NORM
                                      )
                                     ); // sign(pdiff) * sqrt( 2*b^2*( sqrt(1+abs(pdiff)^2/b^2)+1)  )) // <- looks like this without SSE instruction
-      (*pw) = __builtin_ia32_andnps(op->negzero,  (*pd) );                                    
+      (*pw) = _mm_and_ps(op->negzero,  (*pd) );                                    
     }
   }
 }

--- a/src/Utils/FastOpticalFlow/solver.c
+++ b/src/Utils/FastOpticalFlow/solver.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include <omp.h>
 
@@ -85,7 +85,8 @@ void sor_coupled(image_t *du, image_t *dv, image_t *a11, image_t *a12, image_t *
     const int stride = du->stride, width = du->width;
     const int iterheight = du->height-1, iterline = (stride)/4, width_minus_1_sizeoffloat = sizeof(float)*(width-1);
     int j,iter,i,k;
-    float *floatarray = (float*) memalign(16, stride*sizeof(float)*3); 
+    float *floatarray; 
+    int res = posix_memalign((void **) &floatarray, 16, stride*sizeof(float)*3); 
     if(floatarray==NULL){
         fprintf(stderr, "error in sor_coupled(): not enough memory\n");
         exit(1);

--- a/src/Utils/LSQR/lsqrBase.cpp
+++ b/src/Utils/LSQR/lsqrBase.cpp
@@ -594,7 +594,7 @@ Solve( unsigned int m, unsigned int n, const double * b, double * x )
     // See if it is time to print something.
     //----------------------------------------------------------------
     bool prnt = false;
-    if (nout > 0)
+    if (nout != nullptr)
       {
       if (n     <=        40) prnt = true;
       if (this->itn   <=        10) prnt = true;


### PR DESCRIPTION
Some obsolete features (like `malloc.h` and `memalign`) and non-portable versions of SSE intrinsic calls prevented the code from building on macOS. This pull request fixes these problems while ensuring everything still works on Ubuntu 20.04.

Getting OpenMP to work on macOS is an additional stumbling block, but there are instructions for this several places on the web; I used the ones here: https://mac.r-project.org/openmp/.